### PR TITLE
adds .gitignore with apikey.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+apikeys.js


### PR DESCRIPTION
Hey all, I've added a .gitignore file.

I've put in one file, apikeys.js into the .gitignore so that apikeys don't get pushed into the world.

I am also going to send out my apikeys.js file to everyone on our slack channel so that you can have the working api key locally. @BenSurigao I think you mentioned that the cocktails api allows the use of "1" as the apikey for their stuff, so we can probably just use that for now, but if it gets to the point where we need an actual apikey, then we can add that to the same file.